### PR TITLE
Added stopregexes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,25 +7,23 @@
         "@types/mocha": {
             "version": "5.2.5",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
-            "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==",
-            "dev": true
+            "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww=="
         },
         "@types/node": {
-            "version": "10.12.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.10.tgz",
-            "integrity": "sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w==",
-            "dev": true
+            "version": "11.9.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.3.tgz",
+            "integrity": "sha512-DMiqG51GwES/c4ScBY0u5bDlH44+oY8AeYHjY1SGCWidD7h08o1dfHue/TGK7REmif2KiJzaUskO+Q0eaeZ2fQ=="
         },
         "ajv": {
-            "version": "6.5.5",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-            "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+            "version": "6.9.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
+            "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
             "dev": true,
             "requires": {
-                "fast-deep-equal": "2.0.1",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.4.1",
-                "uri-js": "4.2.2"
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             }
         },
         "ansi-cyan": {
@@ -58,7 +56,7 @@
             "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
             "dev": true,
             "requires": {
-                "buffer-equal": "1.0.0"
+                "buffer-equal": "^1.0.0"
             }
         },
         "arr-diff": {
@@ -67,8 +65,8 @@
             "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-slice": "0.2.3"
+                "arr-flatten": "^1.0.1",
+                "array-slice": "^0.2.3"
             }
         },
         "arr-flatten": {
@@ -101,19 +99,13 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
             "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-            "dev": true
-        },
-        "array-unique": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
             "dev": true
         },
         "arrify": {
@@ -128,7 +120,7 @@
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "dev": true,
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": "~2.1.0"
             }
         },
         "assert-plus": {
@@ -167,7 +159,7 @@
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "dev": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "block-stream": {
@@ -176,7 +168,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "brace-expansion": {
@@ -185,19 +177,8 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
-            }
-        },
-        "braces": {
-            "version": "1.8.5",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-            "dev": true,
-            "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.3"
             }
         },
         "browser-stdout": {
@@ -254,9 +235,9 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             }
         },
         "combined-stream": {
@@ -265,7 +246,7 @@
             "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -286,7 +267,7 @@
             "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.1"
             }
         },
         "core-util-is": {
@@ -301,7 +282,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "debug": {
@@ -319,7 +300,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "define-properties": {
@@ -328,7 +309,7 @@
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
             "dev": true,
             "requires": {
-                "object-keys": "1.0.12"
+                "object-keys": "^1.0.12"
             }
         },
         "delayed-stream": {
@@ -350,15 +331,15 @@
             "dev": true
         },
         "duplexify": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
-            "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -367,8 +348,8 @@
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "dev": true,
             "requires": {
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "end-of-stream": {
@@ -377,7 +358,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "escape-string-regexp": {
@@ -387,37 +368,18 @@
             "dev": true
         },
         "event-stream": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-            "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+            "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "flatmap-stream": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.0.7",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "1.0.1",
-                "stream-combiner": "0.2.2",
-                "through": "2.3.8"
-            }
-        },
-        "expand-brackets": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-            "dev": true,
-            "requires": {
-                "is-posix-bracket": "0.1.1"
-            }
-        },
-        "expand-range": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "dev": true,
-            "requires": {
-                "fill-range": "2.2.4"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "extend": {
@@ -432,24 +394,7 @@
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "dev": true,
             "requires": {
-                "kind-of": "1.1.0"
-            }
-        },
-        "extglob": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-            "dev": true,
-            "requires": {
-                "is-extglob": "1.0.0"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                }
+                "kind-of": "^1.1.0"
             }
         },
         "extsprintf": {
@@ -476,63 +421,17 @@
             "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
-        },
-        "filename-regex": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-            "dev": true
-        },
-        "fill-range": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-            "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-            "dev": true,
-            "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "3.1.1",
-                "repeat-element": "1.1.3",
-                "repeat-string": "1.6.1"
-            }
-        },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
-        "flatmap-stream": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
-            "integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw==",
-            "dev": true
         },
         "flush-write-stream": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-            "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+            "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
-            }
-        },
-        "for-in": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-            "dev": true
-        },
-        "for-own": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-            "dev": true,
-            "requires": {
-                "for-in": "1.0.2"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.3.6"
             }
         },
         "forever-agent": {
@@ -547,9 +446,9 @@
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.7",
-                "mime-types": "2.1.21"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
             }
         },
         "from": {
@@ -564,8 +463,8 @@
             "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.15",
-                "through2": "2.0.5"
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
             }
         },
         "fs.realpath": {
@@ -580,10 +479,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.15",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "function-bind": {
@@ -598,7 +497,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "glob": {
@@ -607,48 +506,12 @@
             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-            }
-        },
-        "glob-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "dev": true,
-            "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "2.0.1"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                }
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-parent": {
@@ -657,73 +520,26 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
         "glob-stream": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-            "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+            "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "dev": true,
             "requires": {
-                "extend": "3.0.2",
-                "glob": "5.0.15",
-                "glob-parent": "3.1.0",
-                "micromatch": "2.3.11",
-                "ordered-read-streams": "0.3.0",
-                "through2": "0.6.5",
-                "to-absolute-glob": "0.1.1",
-                "unique-stream": "2.2.1"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "5.0.15",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "dev": true,
-                    "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
-                    }
-                }
+                "extend": "^3.0.0",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
+                "unique-stream": "^2.0.2"
             }
         },
         "graceful-fs": {
@@ -744,9 +560,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.5"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-filter": {
@@ -755,9 +571,9 @@
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             }
         },
         "gulp-gunzip": {
@@ -766,8 +582,8 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             },
             "dependencies": {
                 "isarray": {
@@ -782,10 +598,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -800,23 +616,23 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
         },
         "gulp-remote-src-vscode": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.0.tgz",
-            "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.1.tgz",
+            "integrity": "sha512-mw4OGjtC/jlCWJFhbcAlel4YPvccChlpsl3JceNiB/DLJi24/UPxXt53/N26lgI3dknEqd4ErfdHrO8sJ5bATQ==",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.6",
-                "node.extend": "1.1.7",
-                "request": "2.88.0",
-                "through2": "2.0.5",
-                "vinyl": "2.2.0"
+                "event-stream": "3.3.4",
+                "node.extend": "^1.1.2",
+                "request": "^2.79.0",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.1"
             },
             "dependencies": {
                 "clone": {
@@ -837,64 +653,14 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
-            }
-        },
-        "gulp-sourcemaps": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-            "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-            "dev": true,
-            "requires": {
-                "convert-source-map": "1.6.0",
-                "graceful-fs": "4.1.15",
-                "strip-bom": "2.0.0",
-                "through2": "2.0.5",
-                "vinyl": "1.2.0"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-                    "dev": true
-                },
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
-                }
-            }
-        },
-        "gulp-symdest": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
-            "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
-            "dev": true,
-            "requires": {
-                "event-stream": "3.3.6",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
             }
         },
         "gulp-untar": {
@@ -903,11 +669,11 @@
             "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.6",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.5",
-                "vinyl": "1.2.0"
+                "event-stream": "~3.3.4",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3",
+                "vinyl": "^1.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -928,26 +694,26 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
             }
         },
         "gulp-vinyl-zip": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.1.tgz",
-            "integrity": "sha512-OPnsZkMwiU8UbH5BMlYRb/SccOAZUnwUW7mQvqYadap8MMdgN7ae0ua1rMEE2s9EyqqijN1Sdvoz29/MbPaq9Q==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.2.tgz",
+            "integrity": "sha512-wJn09jsb8PyvUeyFF7y7ImEJqJwYy40BqL9GKfJs6UGpaGW9A+N68Q+ajsIpb9AeR6lAdjMbIdDPclIGo1/b7Q==",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.6",
-                "queue": "4.5.0",
-                "through2": "2.0.5",
-                "vinyl": "2.2.0",
-                "vinyl-fs": "3.0.3",
-                "yauzl": "2.10.0",
-                "yazl": "2.4.3"
+                "event-stream": "3.3.4",
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^3.0.3",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             },
             "dependencies": {
                 "clone": {
@@ -962,95 +728,18 @@
                     "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
                     "dev": true
                 },
-                "glob-stream": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
-                    "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
-                    "dev": true,
-                    "requires": {
-                        "extend": "3.0.2",
-                        "glob": "7.1.3",
-                        "glob-parent": "3.1.0",
-                        "is-negated-glob": "1.0.0",
-                        "ordered-read-streams": "1.0.1",
-                        "pumpify": "1.5.1",
-                        "readable-stream": "2.3.6",
-                        "remove-trailing-separator": "1.1.0",
-                        "to-absolute-glob": "2.0.2",
-                        "unique-stream": "2.2.1"
-                    }
-                },
-                "is-valid-glob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-                    "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
-                    "dev": true
-                },
-                "ordered-read-streams": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
-                    "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "2.3.6"
-                    }
-                },
-                "queue": {
-                    "version": "4.5.0",
-                    "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.0.tgz",
-                    "integrity": "sha512-DwxpAnqJuoQa+wyDgQuwkSshkhlqIlWEvwvdAY27fDPunZ2cVJzXU4JyjY+5l7zs7oGLaYAQm4MbLOVFAHFBzA==",
-                    "dev": true,
-                    "requires": {
-                        "inherits": "2.0.3"
-                    }
-                },
-                "to-absolute-glob": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-                    "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
-                    "dev": true,
-                    "requires": {
-                        "is-absolute": "1.0.0",
-                        "is-negated-glob": "1.0.0"
-                    }
-                },
                 "vinyl": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
-                    }
-                },
-                "vinyl-fs": {
-                    "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
-                    "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
-                    "dev": true,
-                    "requires": {
-                        "fs-mkdirp-stream": "1.0.0",
-                        "glob-stream": "6.1.0",
-                        "graceful-fs": "4.1.15",
-                        "is-valid-glob": "1.0.0",
-                        "lazystream": "1.0.0",
-                        "lead": "1.0.0",
-                        "object.assign": "4.1.0",
-                        "pumpify": "1.5.1",
-                        "readable-stream": "2.3.6",
-                        "remove-bom-buffer": "3.0.0",
-                        "remove-bom-stream": "1.2.0",
-                        "resolve-options": "1.1.0",
-                        "through2": "2.0.5",
-                        "to-through": "2.0.0",
-                        "value-or-function": "3.0.0",
-                        "vinyl": "2.2.0",
-                        "vinyl-sourcemap": "1.1.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -1067,8 +756,8 @@
             "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "dev": true,
             "requires": {
-                "ajv": "6.5.5",
-                "har-schema": "2.0.0"
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
             }
         },
         "has": {
@@ -1077,7 +766,7 @@
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.1.1"
             }
         },
         "has-flag": {
@@ -1104,9 +793,9 @@
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.15.2"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "inflight": {
@@ -1115,8 +804,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -1126,9 +815,9 @@
             "dev": true
         },
         "is": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
-            "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+            "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
             "dev": true
         },
         "is-absolute": {
@@ -1137,35 +826,14 @@
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "is-relative": "1.0.0",
-                "is-windows": "1.0.2"
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
             }
         },
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
-        },
-        "is-dotfile": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-            "dev": true
-        },
-        "is-equal-shallow": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true,
-            "requires": {
-                "is-primitive": "2.0.0"
-            }
-        },
-        "is-extendable": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
             "dev": true
         },
         "is-extglob": {
@@ -1180,7 +848,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
             }
         },
         "is-negated-glob": {
@@ -1189,42 +857,10 @@
             "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
             "dev": true
         },
-        "is-number": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-            "dev": true,
-            "requires": {
-                "kind-of": "3.2.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
-                }
-            }
-        },
         "is-obj": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-            "dev": true
-        },
-        "is-posix-bracket": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-            "dev": true
-        },
-        "is-primitive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
             "dev": true
         },
         "is-relative": {
@@ -1233,14 +869,8 @@
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
-                "is-unc-path": "1.0.0"
+                "is-unc-path": "^1.0.0"
             }
-        },
-        "is-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-            "dev": true
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -1254,7 +884,7 @@
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
-                "unc-path-regex": "0.1.2"
+                "unc-path-regex": "^0.1.2"
             }
         },
         "is-utf8": {
@@ -1264,9 +894,9 @@
             "dev": true
         },
         "is-valid-glob": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-            "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+            "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
             "dev": true
         },
         "is-windows": {
@@ -1280,15 +910,6 @@
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
             "dev": true
-        },
-        "isobject": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-            "dev": true,
-            "requires": {
-                "isarray": "1.0.0"
-            }
         },
         "isstream": {
             "version": "0.1.2",
@@ -1314,25 +935,16 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
-        "json-stable-stringify": {
+        "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-            "dev": true,
-            "requires": {
-                "jsonify": "0.0.0"
-            }
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
         },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-            "dev": true
-        },
-        "jsonify": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
             "dev": true
         },
         "jsprim": {
@@ -1359,7 +971,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.5"
             }
         },
         "lead": {
@@ -1368,91 +980,14 @@
             "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
             "dev": true,
             "requires": {
-                "flush-write-stream": "1.0.3"
+                "flush-write-stream": "^1.0.2"
             }
-        },
-        "lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-            "dev": true
         },
         "map-stream": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-            "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
             "dev": true
-        },
-        "math-random": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-            "dev": true
-        },
-        "merge-stream": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "2.3.6"
-            }
-        },
-        "micromatch": {
-            "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-            "dev": true,
-            "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "1.1.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
-                }
-            }
         },
         "mime-db": {
             "version": "1.37.0",
@@ -1466,7 +1001,7 @@
             "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
             "dev": true,
             "requires": {
-                "mime-db": "1.37.0"
+                "mime-db": "~1.37.0"
             }
         },
         "minimatch": {
@@ -1475,7 +1010,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -1517,12 +1052,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 }
             }
@@ -1539,20 +1074,20 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "node.extend": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.7.tgz",
-            "integrity": "sha512-7Firgqanbd7UtypwBezNTEuo9eHKtEXd+pD96Aj4wai6Q2vM1S38X+MZvR7sQv5E5pj2TZ9j0Am4dLfc6EvKsA==",
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
+            "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
             "dev": true,
             "requires": {
-                "has": "1.0.3",
-                "is": "3.2.1"
+                "has": "^1.0.3",
+                "is": "^3.2.1"
             }
         },
         "normalize-path": {
@@ -1561,7 +1096,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "now-and-later": {
@@ -1570,7 +1105,7 @@
             "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.3.2"
             }
         },
         "oauth-sign": {
@@ -1579,16 +1114,10 @@
             "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
             "dev": true
         },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
-        },
         "object-keys": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+            "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
             "dev": true
         },
         "object.assign": {
@@ -1597,20 +1126,10 @@
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "function-bind": "1.1.1",
-                "has-symbols": "1.0.0",
-                "object-keys": "1.0.12"
-            }
-        },
-        "object.omit": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "dev": true,
-            "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "once": {
@@ -1619,46 +1138,16 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "ordered-read-streams": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
-            "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+            "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
             "dev": true,
             "requires": {
-                "is-stream": "1.1.0",
-                "readable-stream": "2.3.6"
-            }
-        },
-        "parse-glob": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "dev": true,
-            "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                }
+                "readable-stream": "^2.0.1"
             }
         },
         "path-dirname": {
@@ -1679,7 +1168,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -1700,18 +1189,12 @@
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             }
-        },
-        "preserve": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-            "dev": true
         },
         "process-nextick-args": {
             "version": "2.0.0",
@@ -1720,9 +1203,9 @@
             "dev": true
         },
         "psl": {
-            "version": "1.1.29",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-            "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+            "version": "1.1.31",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+            "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
             "dev": true
         },
         "pump": {
@@ -1731,8 +1214,8 @@
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "pumpify": {
@@ -1741,9 +1224,9 @@
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
             "dev": true,
             "requires": {
-                "duplexify": "3.6.1",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
             }
         },
         "punycode": {
@@ -1765,37 +1248,12 @@
             "dev": true
         },
         "queue": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
-            "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.1.tgz",
+            "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
-            }
-        },
-        "randomatic": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-            "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-            "dev": true,
-            "requires": {
-                "is-number": "4.0.0",
-                "kind-of": "6.0.2",
-                "math-random": "1.0.1"
-            },
-            "dependencies": {
-                "is-number": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-                    "dev": true
-                }
+                "inherits": "~2.0.0"
             }
         },
         "readable-stream": {
@@ -1804,22 +1262,13 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
-            }
-        },
-        "regex-cache": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-            "dev": true,
-            "requires": {
-                "is-equal-shallow": "0.1.3"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "remove-bom-buffer": {
@@ -1828,8 +1277,8 @@
             "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6",
-                "is-utf8": "0.2.1"
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
             }
         },
         "remove-bom-stream": {
@@ -1838,27 +1287,15 @@
             "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
             "dev": true,
             "requires": {
-                "remove-bom-buffer": "3.0.0",
-                "safe-buffer": "5.1.2",
-                "through2": "2.0.5"
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
             }
         },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
             "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-            "dev": true
-        },
-        "repeat-element": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-            "dev": true
-        },
-        "repeat-string": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "dev": true
         },
         "replace-ext": {
@@ -1873,26 +1310,26 @@
             "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.8.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.7",
-                "extend": "3.0.2",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.3",
-                "har-validator": "5.1.3",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.21",
-                "oauth-sign": "0.9.0",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "tough-cookie": "2.4.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.3.2"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
             }
         },
         "requires-port": {
@@ -1907,16 +1344,16 @@
             "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
             "dev": true,
             "requires": {
-                "value-or-function": "3.0.0"
+                "value-or-function": "^3.0.0"
             }
         },
         "rimraf": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
             "dev": true,
             "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.1.3"
             }
         },
         "safe-buffer": {
@@ -1944,39 +1381,39 @@
             "dev": true
         },
         "source-map-support": {
-            "version": "0.5.9",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-            "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+            "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.1",
-                "source-map": "0.6.1"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             }
         },
         "split": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+            "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "sshpk": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-            "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
             "dev": true,
             "requires": {
-                "asn1": "0.2.4",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.2",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.2",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "stat-mode": {
@@ -1986,13 +1423,12 @@
             "dev": true
         },
         "stream-combiner": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-            "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "through": "2.3.8"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-shift": {
@@ -2007,7 +1443,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -2022,26 +1458,7 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
-            }
-        },
-        "strip-bom": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "dev": true,
-            "requires": {
-                "is-utf8": "0.2.1"
-            }
-        },
-        "strip-bom-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
-            "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-            "dev": true,
-            "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "safe-buffer": "~5.1.0"
             }
         },
         "supports-color": {
@@ -2050,7 +1467,7 @@
             "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
             "dev": true,
             "requires": {
-                "has-flag": "2.0.0"
+                "has-flag": "^2.0.0"
             }
         },
         "tar": {
@@ -2059,9 +1476,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "through": {
@@ -2076,38 +1493,28 @@
             "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-            "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
             "dev": true,
             "requires": {
-                "through2": "2.0.5",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "to-absolute-glob": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
-            "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+            "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "0.1.1"
-                    }
-                }
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
             }
         },
         "to-through": {
@@ -2116,7 +1523,7 @@
             "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
             "dev": true,
             "requires": {
-                "through2": "2.0.5"
+                "through2": "^2.0.3"
             }
         },
         "tough-cookie": {
@@ -2125,8 +1532,8 @@
             "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
             "dev": true,
             "requires": {
-                "psl": "1.1.29",
-                "punycode": "1.4.1"
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
             },
             "dependencies": {
                 "punycode": {
@@ -2143,7 +1550,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -2165,13 +1572,13 @@
             "dev": true
         },
         "unique-stream": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-            "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+            "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "through2-filter": "^3.0.0"
             }
         },
         "uri-js": {
@@ -2180,7 +1587,7 @@
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "dev": true,
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "^2.1.0"
             }
         },
         "url-parse": {
@@ -2189,8 +1596,8 @@
             "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
             "dev": true,
             "requires": {
-                "querystringify": "2.1.0",
-                "requires-port": "1.0.0"
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "util-deprecate": {
@@ -2205,12 +1612,6 @@
             "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
             "dev": true
         },
-        "vali-date": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
-            "dev": true
-        },
         "value-or-function": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
@@ -2223,9 +1624,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "vinyl": {
@@ -2234,83 +1635,33 @@
             "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
             "dev": true,
             "requires": {
-                "clone": "0.2.0",
-                "clone-stats": "0.0.1"
+                "clone": "^0.2.0",
+                "clone-stats": "^0.0.1"
             }
         },
         "vinyl-fs": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-            "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+            "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
             "dev": true,
             "requires": {
-                "duplexify": "3.6.1",
-                "glob-stream": "5.3.5",
-                "graceful-fs": "4.1.15",
-                "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "0.3.0",
-                "lazystream": "1.0.0",
-                "lodash.isequal": "4.5.0",
-                "merge-stream": "1.0.1",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1",
-                "readable-stream": "2.3.6",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "1.0.0",
-                "through2": "2.0.5",
-                "through2-filter": "2.0.0",
-                "vali-date": "1.0.0",
-                "vinyl": "1.2.0"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-                    "dev": true
-                },
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
-                }
-            }
-        },
-        "vinyl-source-stream": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
-            "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
-            "dev": true,
-            "requires": {
-                "through2": "2.0.5",
-                "vinyl": "0.4.6"
-            }
-        },
-        "vinyl-sourcemap": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
-            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
-            "dev": true,
-            "requires": {
-                "append-buffer": "1.0.2",
-                "convert-source-map": "1.6.0",
-                "graceful-fs": "4.1.15",
-                "normalize-path": "2.1.1",
-                "now-and-later": "2.0.0",
-                "remove-bom-buffer": "3.0.0",
-                "vinyl": "2.2.0"
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
+                "graceful-fs": "^4.0.0",
+                "is-valid-glob": "^1.0.0",
+                "lazystream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
+                "through2": "^2.0.0",
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             },
             "dependencies": {
                 "clone": {
@@ -2331,36 +1682,89 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "vinyl-source-stream": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
+            "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
+            "dev": true,
+            "requires": {
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
+            }
+        },
+        "vinyl-sourcemap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "dev": true,
+            "requires": {
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+                    "dev": true,
+                    "requires": {
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
         },
         "vscode": {
-            "version": "1.1.21",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.21.tgz",
-            "integrity": "sha512-tJl9eL15ZMm6vzCYYeQ26sSYRuXGMGPsaeIAmG2rOOYRn01jdaDg6I4b9G5Ed6FISdmn6egpKThk4o4om8Ax/A==",
+            "version": "1.1.29",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.29.tgz",
+            "integrity": "sha512-E6hzqGtCD65BnBxdZzSIi8FPCM4seEEK/bbTeYdJntg+4D5R6GLbdYFySE9DNTtMJF4iB9UGoucKU/p8Guts1g==",
             "dev": true,
             "requires": {
-                "glob": "7.1.3",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "0.5.0",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.7",
-                "gulp-vinyl-zip": "2.1.1",
-                "mocha": "4.1.0",
-                "request": "2.88.0",
-                "semver": "5.6.0",
-                "source-map-support": "0.5.9",
-                "url-parse": "1.4.4",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src-vscode": "^0.5.1",
+                "gulp-untar": "^0.0.7",
+                "gulp-vinyl-zip": "^2.1.2",
+                "mocha": "^4.0.1",
+                "request": "^2.88.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.4.3",
+                "vinyl-fs": "^3.0.3",
+                "vinyl-source-stream": "^1.1.0"
             }
         },
         "wrappy": {
@@ -2381,17 +1785,17 @@
             "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.1.0"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         },
         "yazl": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
-            "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+            "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,25 @@
 {
-    "name"        : "codealignment-vscode",
-    "displayName" : "Code alignment",
-    "description" : "Code Alignment for Visual Studio Code. Based on the Extension for Visual Studio.",
-    "version"     : "0.0.1",
-    "publisher"   : "cpmcgrath",
-    "engines"     : { "vscode": "^1.19.0" },
-    "categories"  : [ "Formatters" ],
-    "keywords"    : [ "align", "alignment", "formatting" ],
-    "repository": { "type": "git", "url": "https://github.com/cpmcgrath/codealignment-vscode" },
-    "icon"        : "images/CodeAlignment.png",
+    "name": "codealignment-vscode",
+    "displayName": "Code alignment",
+    "description": "Code Alignment for Visual Studio Code. Based on the Extension for Visual Studio.",
+    "version": "0.0.1",
+    "publisher": "cpmcgrath",
+    "engines": {
+        "vscode": "^1.19.0"
+    },
+    "categories": [
+        "Formatters"
+    ],
+    "keywords": [
+        "align",
+        "alignment",
+        "formatting"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/cpmcgrath/codealignment-vscode"
+    },
+    "icon": "images/CodeAlignment.png",
     "activationEvents": [
         "onCommand:codealignment.alignbystring",
         "onCommand:codealignment.alignbyequals",
@@ -19,35 +30,105 @@
     ],
     "main": "./out/extension",
     "contributes": {
-        "commands": [
-            { "command": "codealignment.alignbystring", "title"  : "Align by string (Code Alignment)" },
-            { "command": "codealignment.alignbyequals", "title"  : "Align by equals (Code Alignment)" },
-            { "command": "codealignment.alignbyperiod", "title"  : "Align by period (Code Alignment)" },
-            { "command": "codealignment.alignbyquote",  "title"  : "Align by quote (Code Alignment)" },
-            { "command": "codealignment.alignbyregex",  "title"  : "Align by regex (Code Alignment)" },
-            { "command": "codealignment.alignbyspace",  "title"  : "Align by space (Code Alignment)" }
+        "configuration":[
+            {
+                "title": "codealignment",
+                "properties": {
+                    "codealignment.stopregexes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": []
+                    }
+                }
+
+            }
         ],
-        "keybindings" : [
-            { "command": "codealignment.alignbystring",          "key": "ctrl+shift+=",        "mac": "cmd+shift+=",       "when": "editorTextFocus"},
-            { "command": "codealignment.alignbyequals",          "key": "ctrl+= ctrl+=",       "mac": "cmd+= cmd+=",       "when": "editorTextFocus"},
-            { "command": "codealignment.alignbyequalsfromcaret", "key": "ctrl+= ctrl+shift+=", "mac": "cmd+= cmd+shift+=", "when": "editorTextFocus"},
-            { "command": "codealignment.alignbyperiod",          "key": "ctrl+= ctrl+.",       "mac": "cmd+= cmd+.",       "when": "editorTextFocus"},
-            { "command": "codealignment.alignbyquote",           "key": "ctrl+= ctrl+'",       "mac": "cmd+= cmd+'",       "when": "editorTextFocus"},
-            { "command": "codealignment.alignbyquotefromcaret",  "key": "ctrl+= ctrl+shift+'", "mac": "cmd+= cmd+shift+'", "when": "editorTextFocus"},
-            { "command": "codealignment.alignbyspace",           "key": "ctrl+= ctrl+space",   "mac": "cmd+= cmd+space",   "when": "editorTextFocus"}
+        "commands": [
+            {
+                "command": "codealignment.alignbystring",
+                "title": "Align by string (Code Alignment)"
+            },
+            {
+                "command": "codealignment.alignbyequals",
+                "title": "Align by equals (Code Alignment)"
+            },
+            {
+                "command": "codealignment.alignbyperiod",
+                "title": "Align by period (Code Alignment)"
+            },
+            {
+                "command": "codealignment.alignbyquote",
+                "title": "Align by quote (Code Alignment)"
+            },
+            {
+                "command": "codealignment.alignbyregex",
+                "title": "Align by regex (Code Alignment)"
+            },
+            {
+                "command": "codealignment.alignbyspace",
+                "title": "Align by space (Code Alignment)"
+            }
+        ],
+        "keybindings": [
+            {
+                "command": "codealignment.alignbystring",
+                "key": "ctrl+shift+=",
+                "mac": "cmd+shift+=",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "codealignment.alignbyequals",
+                "key": "ctrl+= ctrl+=",
+                "mac": "cmd+= cmd+=",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "codealignment.alignbyequalsfromcaret",
+                "key": "ctrl+= ctrl+shift+=",
+                "mac": "cmd+= cmd+shift+=",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "codealignment.alignbyperiod",
+                "key": "ctrl+= ctrl+.",
+                "mac": "cmd+= cmd+.",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "codealignment.alignbyquote",
+                "key": "ctrl+= ctrl+'",
+                "mac": "cmd+= cmd+'",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "codealignment.alignbyquotefromcaret",
+                "key": "ctrl+= ctrl+shift+'",
+                "mac": "cmd+= cmd+shift+'",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "codealignment.alignbyspace",
+                "key": "ctrl+= ctrl+space",
+                "mac": "cmd+= cmd+space",
+                "when": "editorTextFocus"
+            }
         ]
     },
     "scripts": {
-        "vscode:prepublish" : "npm run compile",
-        "compile"           : "tsc -p ./",
-        "watch"             : "tsc -watch -p ./",
-        "postinstall"       : "node ./node_modules/vscode/bin/install",
-        "test"              : "npm run compile && node ./node_modules/vscode/bin/test"
+        "vscode:prepublish": "npm run compile",
+        "compile": "tsc -p ./",
+        "watch": "tsc -watch -p ./",
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "test": "npm run compile && node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
-        "typescript"   : "^3.1.6",
-        "vscode"       : "^1.1.21",
-        "@types/node"  : "^10.12.10",
-        "@types/mocha" : "^5.2.5"
+        "typescript": "^3.1.6",
+        "vscode": "^1.1.22"
+    },
+    "dependencies": {
+        "@types/mocha": "^5.2.5",
+        "@types/node": "^11.9.3"
     }
 }

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -1,0 +1,19 @@
+import * as vscode from "vscode"
+
+export interface ICodeAlignmentConfig
+{
+    stopregexes: string[]
+}
+
+export class Config implements ICodeAlignmentConfig
+{
+    stopregexes: string[];
+    
+    public static GetConfig(): ICodeAlignmentConfig
+    {
+        let config =  vscode.workspace.getConfiguration("codealignment");
+        return {
+            stopregexes: config.get<string[]>("stopregexes")
+        }
+    }
+}

--- a/src/common/business/Alignment.ts
+++ b/src/common/business/Alignment.ts
@@ -1,5 +1,5 @@
 ﻿import { NormalDelimiterFinder } from "./delimiterFinders/NormalDelimiterFinder";
-import { LineDetails           } from "./lineDetails";
+import { LineDetails           } from "./LineDetails";
 import { StringFunctions       } from "./tools/StringFunctions";
 import { IDelimiterFinder      } from "./interfaces/IDelimiterFinder";
 import { ArrayFunctions        } from "./tools/ArrayFunctions";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,8 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { Line                 } from './implementation/line'
-import { Document             } from './implementation/document'
+import { Line                 } from './implementation/Line'
+import { Document             } from './implementation/Document'
 import { Alignment            } from './common/business/Alignment'
 import { GeneralScopeSelector } from './common/business/selectors/GeneralScopeSelector';
 import { RegexDelimiterFinder } from './common/business/delimiterFinders/RegexDelimiterFinder';

--- a/src/implementation/Document.ts
+++ b/src/implementation/Document.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { Line } from './line'
-import { Edit } from './edit'
+import { Line } from './Line'
+import { Edit } from './Edit'
 
 export class Document implements IDocument
 {

--- a/src/implementation/Edit.ts
+++ b/src/implementation/Edit.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { Line } from './line'
+import { Line } from './Line'
 
 type ChangeData = { position: vscode.Position; text: string }
 


### PR DESCRIPTION
Lovely extension, but when coding in python it was annoying to me that the line scope selector just ran over comment lines as I think a comment line should be treated just like a blank line. The lack of scope seperators such as { } in python makes this even more annoying. So I implemented a configuration setting called "stopregexes" where each user can define a set of regexes to match the line against. If the match is true, the line will be treated just like a blank line. The name "stopregexes" could maybe be better but if you want to use this code, feel free...